### PR TITLE
fix(deps): pin 'google-{api,cloud}-core', 'google-auth' to allow 2.x versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,10 @@ description = "GKE Hub API client library"
 release_status = "Development Status :: 4 - Beta"
 url = "https://github.com/googleapis/python-gke-hub"
 dependencies = [
-    "google-api-core[grpc] >= 1.26.0, <2.0.0dev",
+    # NOTE: Maintainers, please do not require google-api-core>=2.x.x
+    # Until this issue is closed
+    # https://github.com/googleapis/google-cloud-python/issues/10566
+    "google-api-core[grpc] >= 1.26.0, <3.0.0dev",
     "proto-plus >= 1.4.0",
     "packaging >= 14.3",
 ]


### PR DESCRIPTION
Expand pins on library dependencies in preparation for these dependencies taking a new major version. See https://github.com/googleapis/google-cloud-python/issues/10566.