### PR TITLE
chore: reference main branch of google-cloud-python

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ multiple public clouds.
 - `Product Documentation`_
 
 .. |beta| image:: https://img.shields.io/badge/support-beta-orange.svg
-   :target: https://github.com/googleapis/google-cloud-python/blob/master/README.rst#beta-support
+   :target: https://github.com/googleapis/google-cloud-python/blob/main/README.rst#beta-support
 .. |pypi| image:: https://img.shields.io/pypi/v/google-cloud-gke-hub.svg
    :target: https://pypi.org/project/google-cloud-gke-hub/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-gke-hub.svg
@@ -83,4 +83,4 @@ Next Steps
    APIs that we cover.
 
 .. _GKE Hub Product documentation:  https://cloud.google.com/anthos/gke/docs/
-.. _README: https://github.com/googleapis/google-cloud-python/blob/master/README.rst
+.. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst


### PR DESCRIPTION
Adjust google-cloud-python links to reference main branch.