### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "gkehub",
     "name_pretty": "GKE Hub API",
     "product_documentation": "https://cloud.google.com/anthos/gke/docs/",
-    "client_documentation": "https://googleapis.dev/python/gkehub/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/gkehub/latest",
     "issue_tracker": "",
     "release_level": "ga",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ multiple public clouds.
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-gke-hub.svg
    :target: https://pypi.org/project/google-cloud-gke-hub/
 .. _GKE Hub: https://cloud.google.com/anthos/gke/docs/
-.. _Client Library Documentation: https://googleapis.dev/python/gkehub/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/gkehub/latest
 .. _Product Documentation:  https://cloud.google.com/anthos/gke/docs/
 
 Quick Start


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.